### PR TITLE
Add dynamic children prop support (react-native-read-more-text)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,17 @@
 import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 
+const initialState = {
+  measured: false,
+  shouldShowReadMore: false,
+  showAllText: false
+};
 export default class ReadMore extends React.Component {
-  state = {
-    measured: false,
-    shouldShowReadMore: false,
-    showAllText: false
-  };
+  state = {...initialState};
+
+  resetState() {
+    this.setState({...initialState});
+  }
 
   async componentDidMount() {
     this._isMounted = true;
@@ -16,6 +21,22 @@ export default class ReadMore extends React.Component {
       return;
     }
 
+    this.compareTextHeightMeasurements()
+  }
+  
+  async componentDidUpdate(prevProps) {
+    if (this.props.children !== prevProps.children) {
+      this.resetState();
+      await nextFrameAsync();
+      this.compareTextHeightMeasurements();
+    }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+  
+  async compareTextHeightMeasurements() {
     // Get the height of the text with no restriction on number of lines
     const fullHeight = await measureHeightAsync(this._text);
     this.setState({ measured: true });
@@ -35,10 +56,6 @@ export default class ReadMore extends React.Component {
     } else {
       this.props.onReady && this.props.onReady();
     }
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
   }
 
   render() {


### PR DESCRIPTION
Add dynamic children prop support so if children are changed it's being taken into account while setting component state leading to proper "Show more", "Show less" buttons behavior.

The problem: if the children prop is a dynamic one, the component doesn't behave as expected (meaning "Show more" button visibility is being decided only on the mount stage).

Current behavior:
![current](https://user-images.githubusercontent.com/25992258/100998379-1d545580-3564-11eb-8a5f-ad8ebedcc4b5.gif)

Desired behavior:
![updates](https://user-images.githubusercontent.com/25992258/100998420-2a714480-3564-11eb-8e67-4d0b18b758de.gif)
