### PR TITLE
add allowFontScalingOption

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ export default class ReadMore extends React.Component {
           ref={text => {
             this._text = text;
           }}
+          allowFontScaling={this.props.allowFontScaling}
         >
           {this.props.children}
         </Text>


### PR DESCRIPTION
add allowFontScalingOption

If  stack <Text> twice, allowFontscaling of child will not work.
Therefore, allowFontscaling cannot be set in <Readmore>.
``` jsx
<Text>
  {/* allowFontScaling={false} not work */}
  <Text allowFontScaling={false}>text</Text>
</Text>;
```